### PR TITLE
added chunk generator replacement hook

### DIFF
--- a/src/main/java/org/dimdev/rift/listener/ChunkGeneratorReplacer.java
+++ b/src/main/java/org/dimdev/rift/listener/ChunkGeneratorReplacer.java
@@ -1,0 +1,29 @@
+package org.dimdev.rift.listener;
+
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.gen.ChunkGeneratorType;
+import net.minecraft.world.gen.IChunkGenSettings;
+import net.minecraft.world.gen.IChunkGenerator;
+import net.minecraft.world.gen.IChunkGeneratorFactory;
+
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+/**
+ * used to substitute custom {@link IChunkGenerator}s for vanilla ones<br/>
+ * <b>NOTE:</b><br/>
+ *  custom {@link WorldType}s are registered by just instantiating them<br/>
+ *  custom {@link ChunkGeneratorType}s are registered via {@link ChunkGeneratorType#registerChunkGeneratorType(String, IChunkGeneratorFactory, ChunkGeneratorType.Settings, boolean)}<br/>
+ *  custom {@link ChunkGeneratorType.Settings} are registered via {@link ChunkGeneratorType.Settings#registerChunkGeneratorSettings(String, Supplier)}
+ */
+public interface ChunkGeneratorReplacer {
+
+    /**
+     * create an {@link IChunkGenerator} for your world type
+     * @param worldType the world type that is currently set
+     * @return a custom chunk generator or {@code null} to fall back to vanilla chunk generator selection
+     */
+    @Nullable
+    <T extends IChunkGenSettings> IChunkGenerator<T> createChunkGenerator(WorldServer world, WorldType worldType, int dimensionID);
+}

--- a/src/main/java/org/dimdev/rift/mixin/hook/MixinWorldServer.java
+++ b/src/main/java/org/dimdev/rift/mixin/hook/MixinWorldServer.java
@@ -1,0 +1,29 @@
+package org.dimdev.rift.mixin.hook;
+
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.dimension.Dimension;
+import net.minecraft.world.gen.IChunkGenSettings;
+import net.minecraft.world.gen.IChunkGenerator;
+import org.dimdev.rift.listener.ChunkGeneratorReplacer;
+import org.dimdev.riftloader.RiftLoader;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(WorldServer.class)
+public class MixinWorldServer {
+
+    @SuppressWarnings("ConstantConditions")
+    @Redirect(method = "createChunkProvider", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/dimension/Dimension;createChunkGenerator()Lnet/minecraft/world/gen/IChunkGenerator;"))
+    protected <T extends IChunkGenSettings> IChunkGenerator onCreateChunkGenerator(Dimension provider) {
+        WorldServer world = (WorldServer) (Object) this;
+        WorldType type = world.getWorldInfo().getTerrainType();
+        IChunkGenerator<T> generator = null;
+        for(ChunkGeneratorReplacer adder : RiftLoader.instance.getListeners(ChunkGeneratorReplacer.class)) {
+            IChunkGenerator<T> value = adder.createChunkGenerator(world, type, provider.getDimensionType().getId());
+            if(value != null) generator = value;
+        }
+        return generator != null ? generator : provider.createChunkGenerator();
+    }
+}

--- a/src/main/resources/access_transformations.at
+++ b/src/main/resources/access_transformations.at
@@ -24,3 +24,7 @@ public method awa a (Ljava/lang/String;Lawa;)V
 public method aeg a (ILjava/lang/String;Laeg;)V
 public method bfl <init> (Lbyl;Lbcj$c;)V
 public method wh a (Ljava/lang/String;)V
+public method axz <init> (ILjava/lang/String;)V #WorldType
+public method axz <init> (ILjava/lang/String;I)V #WorldType
+public method axz <init> (ILjava/lang/String;Ljava/lang/String;I)V #WorldType
+public class bmr #IChunkGeneratorFactory

--- a/src/main/resources/mixins.rift.hooks.json
+++ b/src/main/resources/mixins.rift.hooks.json
@@ -34,7 +34,8 @@
     "MixinCPacketCustomPayload",
     "client.MixinEntityPlayerSP",
     "MixinEntityType$Builder",
-    "client.MixinGuiIngame"
+    "client.MixinGuiIngame",
+    "MixinWorldServer"
   ],
   "client": []
 }


### PR DESCRIPTION
added hook for replacing chunk generators
this allows mods to override vanilla chunk generators or to add their own when registering a new world type.

also added ATs for `WorldType` and `IChunkGeneratorFactory ` so modders can use them.