### PR TITLE
made installer use correct rift version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ minecraft {
     runDir = 'run'
     tweakClass = 'org.dimdev.riftloader.launch.RiftLoaderTweaker'
     makeObfSourceJar = false
+
+    replace "@VERSION@", project.version
+    replaceIn "org/dimdev/rift/Installer.java"
 }
 
 mixin {

--- a/src/main/java/org/dimdev/rift/Installer.java
+++ b/src/main/java/org/dimdev/rift/Installer.java
@@ -22,7 +22,7 @@ public class Installer {
                 minecraftFolder = new File(userHome + "/.minecraft");
             }
 
-            File target = new File(minecraftFolder, "versions/1.13-rift-1.0.1/1.13-rift-1.0.1.json");
+            File target = new File(minecraftFolder, "versions/1.13-rift-@VERSION@/1.13-rift-@VERSION@.json");
             target.getParentFile().mkdirs();
             Files.copy(Installer.class.getResourceAsStream("/profile.json"), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
@@ -32,7 +32,7 @@ public class Installer {
                 t.printStackTrace();
             }
             JOptionPane.showMessageDialog(null,
-                    "Rift 1.0.1 for Minecraft 1.13 has been successfully installed!\n\n" +
+                    "Rift @VERSION@ for Minecraft 1.13 has been successfully installed!\n\n" +
                     "It is available in the \"Version\" dropdown menu in the \"Launch Options\"\n" +
                     "section of the launcher.", "Rift Installer", JOptionPane.INFORMATION_MESSAGE);
         } catch (Throwable t) {


### PR DESCRIPTION
this fixes the Rift installer using version 1.0.1 when creating the launcher profile, by automatically setting the correct version when building the jar