### PR TITLE
Add versioning and dependencies to Rift loader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation('net.minecraft:launchwrapper:1.12') { transitive = false }
     implementation 'org.ow2.asm:asm:6.2'
     implementation 'org.ow2.asm:asm-commons:6.2'
+    compile 'com.vdurmont:semver4j:2.2.0'
 }
 
 minecraft {

--- a/src/main/java/org/dimdev/riftloader/MissingDependencyException.java
+++ b/src/main/java/org/dimdev/riftloader/MissingDependencyException.java
@@ -1,0 +1,7 @@
+package org.dimdev.riftloader;
+
+public class MissingDependencyException extends RuntimeException {
+    public MissingDependencyException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/org/dimdev/riftloader/ModInfo.java
+++ b/src/main/java/org/dimdev/riftloader/ModInfo.java
@@ -12,7 +12,7 @@ public class ModInfo {
     public String id;
     public String name;
     public String version;
-    public Map<String, String> dependencies = new HashMap<>();
+    public Map<String, Map.Entry<String, String>> dependencies = new HashMap<>();
     public List<String> authors = new ArrayList<>();
     public List<String> listeners = new ArrayList<>();
 }

--- a/src/main/java/org/dimdev/riftloader/ModInfo.java
+++ b/src/main/java/org/dimdev/riftloader/ModInfo.java
@@ -2,7 +2,9 @@ package org.dimdev.riftloader;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ModInfo {
     public File source;
@@ -10,7 +12,7 @@ public class ModInfo {
     public String id;
     public String name;
     public String version;
-    public List<String, String> dependencies = new ArrayList<>();
+    public Map<String, String> dependencies = new HashMap<>();
     public List<String> authors = new ArrayList<>();
     public List<String> listeners = new ArrayList<>();
 }

--- a/src/main/java/org/dimdev/riftloader/ModInfo.java
+++ b/src/main/java/org/dimdev/riftloader/ModInfo.java
@@ -12,7 +12,7 @@ public class ModInfo {
     public String id;
     public String name;
     public String version;
-    public Map<String, Map.Entry<String, String>> dependencies = new HashMap<>();
+    public Map<String, String> dependencies = new HashMap<>();
     public List<String> authors = new ArrayList<>();
     public List<String> listeners = new ArrayList<>();
 }

--- a/src/main/java/org/dimdev/riftloader/ModInfo.java
+++ b/src/main/java/org/dimdev/riftloader/ModInfo.java
@@ -9,6 +9,8 @@ public class ModInfo {
 
     public String id;
     public String name;
+    public String version;
+    public List<String, String> dependencies = new ArrayList<>();
     public List<String> authors = new ArrayList<>();
     public List<String> listeners = new ArrayList<>();
 }

--- a/src/main/java/org/dimdev/riftloader/RiftLoader.java
+++ b/src/main/java/org/dimdev/riftloader/RiftLoader.java
@@ -145,7 +145,7 @@ public class RiftLoader {
                 return;
             } else {
                 try {
-                    Semver version = new Semver(modInfo.version);
+                    Semver version = new Semver(modInfo.version, Semver.SemverType.LOOSE);
                 } catch (SemverException t) {
                     log.error("Mod file " + modInfo.source + "'s riftmod.json has a malformed 'version' field");
                     log.error("SemVer error: " + t.getMessage());
@@ -184,11 +184,16 @@ public class RiftLoader {
                         throw new MissingDependencyException("Mod " + modInfo.source + " is missing dependency " + name + ":" + modInfo.dependencies.get(name));
                     }
                     ModInfo dependency = modInfoMap.get(name);
-                    Semver neededVersion = new Semver(modInfo.dependencies.get(name));
-                    Semver trueVersion = new Semver(dependency.version);
-                    if (trueVersion.isLowerThan(neededVersion)) {
-                        throw new MissingDependencyException("Mod " + modInfo.source + " has outdated dependency " + name + ": must be at least " + neededVersion);
+                    try {
+                        Semver neededVersion = new Semver(modInfo.dependencies.get(name), Semver.SemverType.LOOSE);
+                        Semver trueVersion = new Semver(dependency.version, Semver.SemverType.LOOSE);
+                        if (trueVersion.isLowerThan(neededVersion)) {
+                            throw new MissingDependencyException("Mod " + modInfo.source + " has outdated dependency " + name + ": must be at least " + neededVersion);
+                        }
+                    } catch (SemverException t) {
+                        throw new MissingDependencyException("Mod " + modInfo.source + " has malformed dependency " + name + ": SemVer error " + t.getMessage());
                     }
+
                 }
             }
         }

--- a/src/main/java/org/dimdev/riftloader/RiftLoader.java
+++ b/src/main/java/org/dimdev/riftloader/RiftLoader.java
@@ -131,6 +131,8 @@ public class RiftLoader {
             ModInfo modInfo = GSON.fromJson(new InputStreamReader(in), ModInfo.class);
             modInfo.source = source;
 
+
+
             // Make sure the id isn't null and there aren't any duplicates
             if (modInfo.id == null) {
                 log.error("Mod file " + modInfo.source + "'s riftmod.json is missing a 'id' field");
@@ -185,18 +187,11 @@ public class RiftLoader {
                     }
                     ModInfo dependency = modInfoMap.get(id);
                     Semver trueVersion = new Semver(dependency.version, Semver.SemverType.LOOSE);
-                    Map.Entry<String, String> versions = modInfo.dependencies.get(id);
                     try {
-                        Semver lowestVersion = new Semver(versions.getKey(), Semver.SemverType.LOOSE);
+                        Semver lowestVersion = new Semver(modInfo.dependencies.get(id), Semver.SemverType.LOOSE);
 
                         if (trueVersion.isLowerThan(lowestVersion)) {
                             throw new MissingDependencyException("Mod " + modInfo.source + " has outdated dependency: " + id + " must be at least " + lowestVersion);
-                        }
-                        if (versions.getValue() != null) {
-                            Semver highestVersion = new Semver(versions.getValue(), Semver.SemverType.LOOSE);
-                            if (trueVersion.isGreaterThan(highestVersion)) {
-                                throw new MissingDependencyException("Mod " + modInfo.source + " has misdated dependency: " + id + " must be at most " + highestVersion);
-                            }
                         }
                     } catch (SemverException t) {
                         throw new MissingDependencyException("Mod " + modInfo.source + " has malformed dependency in " + id + ": SemVer error " + t.getMessage());

--- a/src/main/resources/riftmod.json
+++ b/src/main/resources/riftmod.json
@@ -1,6 +1,7 @@
 {
   "id": "rift",
   "name": "Rift",
+  "version": "1.0.3-SNAPSHOT",
   "authors": [
     "Runemoro"
   ],


### PR DESCRIPTION
Adds new elements to a Rift mod json: a version String and a dependencies Map<String, String>. The first String in the dependency map is the mod's id, and the second is the minimum version needed.

Version strings are parsed as loose SemVer, and will fail to load (without crashing the game) if there is a missing version (though we might want to give them a dummy version instead for backwards compat). Incorrect dependencies will throw a new MissingDependencyException.

To keep OptiFine being loadable, it has been given its own version string of "1.13".

This is tested and works perfectly. In the future, it would be good to make this crash without closing the Minecraft window a la Forge's dependency catcher, but that's not something I'm able to write at the moment.