### PR TITLE
Add documenting ListenerInterface annotation

### DIFF
--- a/src/main/java/org/dimdev/rift/listener/BiomeAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/BiomeAdder.java
@@ -4,6 +4,7 @@ import net.minecraft.world.biome.Biome;
 
 import java.util.Collection;
 
+@ListenerInterface
 public interface BiomeAdder {
     void registerBiomes();
     Collection<Biome> getOverworldBiomes();

--- a/src/main/java/org/dimdev/rift/listener/BlockAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/BlockAdder.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface BlockAdder {
     void registerBlocks();
 }

--- a/src/main/java/org/dimdev/rift/listener/BootstrapListener.java
+++ b/src/main/java/org/dimdev/rift/listener/BootstrapListener.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface BootstrapListener {
     void afterVanillaBootstrap();
 }

--- a/src/main/java/org/dimdev/rift/listener/BurnTimeProvider.java
+++ b/src/main/java/org/dimdev/rift/listener/BurnTimeProvider.java
@@ -3,6 +3,7 @@ package org.dimdev.rift.listener;
 import net.minecraft.item.Item;
 import java.util.Map;
 
+@ListenerInterface
 public interface BurnTimeProvider {
     void registerBurnTimes(Map<Item, Integer> burnTimeMap);
 }

--- a/src/main/java/org/dimdev/rift/listener/ChunkEventListener.java
+++ b/src/main/java/org/dimdev/rift/listener/ChunkEventListener.java
@@ -2,6 +2,7 @@ package org.dimdev.rift.listener;
 
 import net.minecraft.world.chunk.Chunk;
 
+@ListenerInterface
 public interface ChunkEventListener {
     void onChunkLoad(Chunk chunk);
     void onChunkUnload(Chunk chunk);

--- a/src/main/java/org/dimdev/rift/listener/ChunkGeneratorReplacer.java
+++ b/src/main/java/org/dimdev/rift/listener/ChunkGeneratorReplacer.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
  *  custom {@link ChunkGeneratorType}s are registered via {@link ChunkGeneratorType#registerChunkGeneratorType(String, IChunkGeneratorFactory, ChunkGeneratorType.Settings, boolean)}<br/>
  *  custom {@link ChunkGeneratorType.Settings} are registered via {@link ChunkGeneratorType.Settings#registerChunkGeneratorSettings(String, Supplier)}
  */
+@ListenerInterface
 public interface ChunkGeneratorReplacer {
 
     /**

--- a/src/main/java/org/dimdev/rift/listener/CommandAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/CommandAdder.java
@@ -3,6 +3,7 @@ package org.dimdev.rift.listener;
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.command.CommandSource;
 
+@ListenerInterface
 public interface CommandAdder {
     void registerCommands(CommandDispatcher<CommandSource> dispatcher);
 }

--- a/src/main/java/org/dimdev/rift/listener/CustomPayloadHandler.java
+++ b/src/main/java/org/dimdev/rift/listener/CustomPayloadHandler.java
@@ -8,6 +8,7 @@ import net.minecraft.util.ResourceLocation;
  */
 @Deprecated
 @SuppressWarnings("DeprecatedIsStillUsed")
+@ListenerInterface
 public interface CustomPayloadHandler {
     boolean clientHandlesChannel(ResourceLocation channelName);
     void clientHandleCustomPayload(ResourceLocation channelName, PacketBuffer bufferData);

--- a/src/main/java/org/dimdev/rift/listener/DataPackFinderAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/DataPackFinderAdder.java
@@ -4,6 +4,7 @@ import net.minecraft.resources.IPackFinder;
 
 import java.util.List;
 
+@ListenerInterface
 public interface DataPackFinderAdder {
     List<IPackFinder> getDataPackFinders();
 }

--- a/src/main/java/org/dimdev/rift/listener/DimensionTypeAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/DimensionTypeAdder.java
@@ -7,6 +7,7 @@ import org.dimdev.utils.ReflectionUtils;
 import java.util.Set;
 import java.util.function.Supplier;
 
+@ListenerInterface
 public interface DimensionTypeAdder {
     static DimensionType newDimensionType(int id, String name, String suffix, Supplier<? extends Dimension> dimensionSupplier) {
         return ReflectionUtils.makeEnumInstance(DimensionType.class, name.toUpperCase(), -1, id, name, suffix, dimensionSupplier);

--- a/src/main/java/org/dimdev/rift/listener/DispenserBehaviorAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/DispenserBehaviorAdder.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface DispenserBehaviorAdder {
     void registerDispenserBehaviors();
 }

--- a/src/main/java/org/dimdev/rift/listener/EnchantmentAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/EnchantmentAdder.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface EnchantmentAdder {
     void registerEnchantments();
 }

--- a/src/main/java/org/dimdev/rift/listener/EntityTypeAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/EntityTypeAdder.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface EntityTypeAdder {
     void registerEntityTypes();
 }

--- a/src/main/java/org/dimdev/rift/listener/FluidAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/FluidAdder.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface FluidAdder {
     void registerFluids();
 }

--- a/src/main/java/org/dimdev/rift/listener/ItemAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/ItemAdder.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface ItemAdder {
     void registerItems();
 }

--- a/src/main/java/org/dimdev/rift/listener/ListenerInterface.java
+++ b/src/main/java/org/dimdev/rift/listener/ListenerInterface.java
@@ -1,0 +1,19 @@
+package org.dimdev.rift.listener;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An informative annotation type used to indicate that an interface
+ * type declaration is intended to be a <i>listener interface</i>.
+ * However, Rift will treat any given interface as a listener interface
+ * at runtime, regardless of whether or not a {@code ListenerInterface}
+ * annotation is present on the interface declaration.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ListenerInterface {}

--- a/src/main/java/org/dimdev/rift/listener/MessageAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/MessageAdder.java
@@ -4,6 +4,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.RegistryNamespaced;
 import org.dimdev.rift.network.Message;
 
+@ListenerInterface
 public interface MessageAdder {
     void registerMessages(RegistryNamespaced<ResourceLocation, Class<? extends Message>> registry);
 }

--- a/src/main/java/org/dimdev/rift/listener/MinecraftStartListener.java
+++ b/src/main/java/org/dimdev/rift/listener/MinecraftStartListener.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface MinecraftStartListener {
     void onMinecraftStart();
 }

--- a/src/main/java/org/dimdev/rift/listener/MobEffectAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/MobEffectAdder.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface MobEffectAdder {
     void registerMobEffects();
 }

--- a/src/main/java/org/dimdev/rift/listener/PacketAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/PacketAdder.java
@@ -4,6 +4,7 @@ import net.minecraft.network.EnumConnectionState;
 import net.minecraft.network.EnumPacketDirection;
 import net.minecraft.network.Packet;
 
+@ListenerInterface
 public interface PacketAdder {
     interface PacketRegistrationReceiver {
         EnumConnectionState registerPacket(EnumPacketDirection direction, Class<? extends Packet<?>> packetClass);

--- a/src/main/java/org/dimdev/rift/listener/ParticleTypeAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/ParticleTypeAdder.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface ParticleTypeAdder {
     void registerParticles();
 }

--- a/src/main/java/org/dimdev/rift/listener/ResourcePackFinderAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/ResourcePackFinderAdder.java
@@ -4,6 +4,7 @@ import net.minecraft.resources.IPackFinder;
 
 import java.util.List;
 
+@ListenerInterface
 public interface ResourcePackFinderAdder {
     List<IPackFinder> getResourcePackFinders();
 }

--- a/src/main/java/org/dimdev/rift/listener/ServerTickable.java
+++ b/src/main/java/org/dimdev/rift/listener/ServerTickable.java
@@ -2,6 +2,7 @@ package org.dimdev.rift.listener;
 
 import net.minecraft.server.MinecraftServer;
 
+@ListenerInterface
 public interface ServerTickable {
     void serverTick(MinecraftServer server);
 }

--- a/src/main/java/org/dimdev/rift/listener/SoundAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/SoundAdder.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface SoundAdder {
     void registerSounds();
 }

--- a/src/main/java/org/dimdev/rift/listener/StructureAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/StructureAdder.java
@@ -4,6 +4,7 @@ import net.minecraft.world.gen.feature.structure.Structure;
 
 import java.util.Map;
 
+@ListenerInterface
 public interface StructureAdder {
     /** Register structure and structure and peice names in {@link net.minecraft.world.gen.feature.structure.StructureIO}.*/
     void registerStructureNames();

--- a/src/main/java/org/dimdev/rift/listener/TileEntityTypeAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/TileEntityTypeAdder.java
@@ -1,5 +1,6 @@
 package org.dimdev.rift.listener;
 
+@ListenerInterface
 public interface TileEntityTypeAdder {
     void registerTileEntityTypes();
 }

--- a/src/main/java/org/dimdev/rift/listener/WorldChanger.java
+++ b/src/main/java/org/dimdev/rift/listener/WorldChanger.java
@@ -2,6 +2,7 @@ package org.dimdev.rift.listener;
 
 import net.minecraft.world.biome.Biome;
 
+@ListenerInterface
 public interface WorldChanger {
     void modifyBiome(int biomeId, String biomeName, Biome biome);
 }

--- a/src/main/java/org/dimdev/rift/listener/client/AmbientMusicTypeProvider.java
+++ b/src/main/java/org/dimdev/rift/listener/client/AmbientMusicTypeProvider.java
@@ -2,10 +2,12 @@ package org.dimdev.rift.listener.client;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.SoundEvent;
+import org.dimdev.rift.listener.ListenerInterface;
 import org.dimdev.utils.ReflectionUtils;
 
 import static net.minecraft.client.audio.MusicTicker.MusicType;
 
+@ListenerInterface
 public interface AmbientMusicTypeProvider {
     static MusicType newMusicType(String name, SoundEvent sound, int minDelay, int maxDelay) {
         return ReflectionUtils.makeEnumInstance(MusicType.class, name, -1, sound, minDelay, maxDelay);

--- a/src/main/java/org/dimdev/rift/listener/client/ClientTickable.java
+++ b/src/main/java/org/dimdev/rift/listener/client/ClientTickable.java
@@ -1,5 +1,8 @@
 package org.dimdev.rift.listener.client;
 
+import org.dimdev.rift.listener.ListenerInterface;
+
+@ListenerInterface
 public interface ClientTickable {
     void clientTick();
 }

--- a/src/main/java/org/dimdev/rift/listener/client/EntityRendererAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/client/EntityRendererAdder.java
@@ -3,9 +3,11 @@ package org.dimdev.rift.listener.client;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.Entity;
+import org.dimdev.rift.listener.ListenerInterface;
 
 import java.util.Map;
 
+@ListenerInterface
 public interface EntityRendererAdder {
     void addEntityRenderers(Map<Class<? extends Entity>, Render<? extends Entity>> entityRenderMap, RenderManager renderManager);
 }

--- a/src/main/java/org/dimdev/rift/listener/client/GameGuiAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/client/GameGuiAdder.java
@@ -3,7 +3,9 @@ package org.dimdev.rift.listener.client;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.world.IInteractionObject;
+import org.dimdev.rift.listener.ListenerInterface;
 
+@ListenerInterface
 public interface GameGuiAdder {
     void displayGui(EntityPlayerSP player, String id, IInteractionObject interactionObject);
     void displayContainerGui(EntityPlayerSP player, String id, IInventory inventory);

--- a/src/main/java/org/dimdev/rift/listener/client/KeybindHandler.java
+++ b/src/main/java/org/dimdev/rift/listener/client/KeybindHandler.java
@@ -1,5 +1,8 @@
 package org.dimdev.rift.listener.client;
 
+import org.dimdev.rift.listener.ListenerInterface;
+
+@ListenerInterface
 public interface KeybindHandler {
     void processKeybinds();
 }

--- a/src/main/java/org/dimdev/rift/listener/client/OverlayRenderer.java
+++ b/src/main/java/org/dimdev/rift/listener/client/OverlayRenderer.java
@@ -1,5 +1,8 @@
 package org.dimdev.rift.listener.client;
 
+import org.dimdev.rift.listener.ListenerInterface;
+
+@ListenerInterface
 public interface OverlayRenderer {
     void renderOverlay();
 }

--- a/src/main/java/org/dimdev/rift/listener/client/TextureAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/client/TextureAdder.java
@@ -1,9 +1,11 @@
 package org.dimdev.rift.listener.client;
 
 import net.minecraft.util.ResourceLocation;
+import org.dimdev.rift.listener.ListenerInterface;
 
 import java.util.Collection;
 
+@ListenerInterface
 public interface TextureAdder {
     Collection<? extends ResourceLocation> getBuiltinTextures();
 }

--- a/src/main/java/org/dimdev/rift/listener/client/TileEntityRendererAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/client/TileEntityRendererAdder.java
@@ -2,9 +2,11 @@ package org.dimdev.rift.listener.client;
 
 import net.minecraft.client.renderer.tileentity.TileEntityRenderer;
 import net.minecraft.tileentity.TileEntity;
+import org.dimdev.rift.listener.ListenerInterface;
 
 import java.util.Map;
 
+@ListenerInterface
 public interface TileEntityRendererAdder {
     void addTileEntityRenderers(Map<Class<? extends TileEntity>, TileEntityRenderer<? extends TileEntity>> renderers);
 }


### PR DESCRIPTION
An annotation used for documenting a listener interface. The retention policy is equivalent to that used for Java's [FunctionalInterface](https://docs.oracle.com/javase/8/docs/api/java/lang/FunctionalInterface.html) annotation, which will allow for reflective lookups to determine the presence of the annotation at runtime too if ever desired.
