### PR TITLE
Allow loading mods from version-specified directory i.e. mods/rift/1.13/

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ minecraft {
 
     replace "@VERSION@", project.version
     replaceIn "org/dimdev/riftloader/Main.java"
+
+    replace "@MCVERSION@", project.minecraft.version
+    replaceIn "org/dimdev/riftloader/RiftLoader.java"
 }
 
 mixin {

--- a/src/main/java/org/dimdev/riftloader/RiftLoader.java
+++ b/src/main/java/org/dimdev/riftloader/RiftLoader.java
@@ -29,9 +29,9 @@ public class RiftLoader {
     public static final RiftLoader instance = new RiftLoader();
     private static final Logger log = LogManager.getLogger("RiftLoader");
 
-    public File modsDir = new File(Launch.minecraftHome, "mods");
-    public final File modsVersionSpecifiedDir = new File(Launch.minecraftHome, "mods/rift/@MCVERSION@");
-    public final File modsRiftDir = new File(Launch.minecraftHome, "mods/rift");
+    public final File modsDir = new File(Launch.minecraftHome, "mods");
+    public final File modsRiftDir = new File(modsDir, "rift");
+    public final File modsVersionSpecifiedDir = new File(modsRiftDir, "@MCVERSION@");
     public final File configDir = new File(Launch.minecraftHome, "config");
     private Side side;
     private boolean loaded;
@@ -53,16 +53,8 @@ public class RiftLoader {
 
         // load mods from classpath
         findClasspathMods();
-        // test if mods/rift/"version"/ contains any .jar files, then load from it
-        if (modsVersionSpecifiedDir.exists() && modsVersionSpecifiedDir.isDirectory()) {
-            // search and load mods from mods/rift/"version"/ if there are mods inside
-            for (File tempFile : modsVersionSpecifiedDir.listFiles()) {
-                if (tempFile.getName().toLowerCase().endsWith((".jar"))) {
-                    findJarMods(modsVersionSpecifiedDir);
-                    break;
-                }
-            }
-        }
+        // load mods from mods/rift/"version"/
+        findJarMods(modsVersionSpecifiedDir);
         // load mods from folder mods/rift/, create the folder if not exists
         findJarMods(modsRiftDir, true);
         // load mods from mods/, create the folder if not exists
@@ -123,11 +115,17 @@ public class RiftLoader {
     }
 
     private void findJarMods(File modsDir, boolean createDir) {
+        if (createDir) {
+            // create dir if needed
+            modsDir.mkdirs();
+        } else if (!modsVersionSpecifiedDir.isDirectory()) {
+            // skip loading if folder not exists
+            return;
+        }
         int modCount = modInfoMap.size();
         log.info("Searching for mods in " + modsDir);
-        if (createDir) modsDir.mkdirs();
         for (File file : modsDir.listFiles()) {
-             if (!file.getName().toLowerCase().endsWith(".jar")) continue;
+            if (!file.getName().toLowerCase().endsWith(".jar")) continue;
 
             try (JarFile jar = new JarFile(file)) {
                 // Check if the file contains a 'riftmod.json'

--- a/src/main/java/org/dimdev/riftloader/RiftLoader.java
+++ b/src/main/java/org/dimdev/riftloader/RiftLoader.java
@@ -64,9 +64,9 @@ public class RiftLoader {
             }
         }
         // load mods from folder mods/rift/, create the folder if not exists
-        findJarMods(modsRiftDir,true);
+        findJarMods(modsRiftDir, true);
         // load mods from mods/, create the folder if not exists
-        findJarMods(modsDir,true);
+        findJarMods(modsDir, true);
         sortMods();
         initMods();
         initAccessTransformer();
@@ -121,7 +121,8 @@ public class RiftLoader {
     private void findJarMods(File modsDir) {
         this.findJarMods(modsDir, false);
     }
-    private void findJarMods(File modsDir, Boolean createDir) {
+
+    private void findJarMods(File modsDir, boolean createDir) {
         int modCount = modInfoMap.size();
         log.info("Searching for mods in " + modsDir);
         if (createDir) modsDir.mkdirs();

--- a/src/main/java/org/dimdev/riftloader/RiftLoader.java
+++ b/src/main/java/org/dimdev/riftloader/RiftLoader.java
@@ -51,13 +51,14 @@ public class RiftLoader {
         side = isClient ? Side.CLIENT : Side.SERVER;
 
         // test if mods/"version"-Rift contains any .jar files
-        modsVersionSpecifiedDir.mkdir();
-        for (File tempFile : modsVersionSpecifiedDir.listFiles()) {
-            // test if dir contains any .jar files
-            if (tempFile.getName().toLowerCase().endsWith((".jar"))) {
-                // load mods from mods/"version"-Rift folder
-                modsDir = modsVersionSpecifiedDir;
-                break;
+        if (modsVersionSpecifiedDir.exists() && modsVersionSpecifiedDir.isDirectory()) {
+            for (File tempFile : modsVersionSpecifiedDir.listFiles()) {
+                // test if dir contains any .jar files
+                if (tempFile.getName().toLowerCase().endsWith((".jar"))) {
+                    // load mods from mods/"version"-Rift folder
+                    modsDir = modsVersionSpecifiedDir;
+                    break;
+                }
             }
         }
 

--- a/src/main/java/org/dimdev/riftloader/RiftLoader.java
+++ b/src/main/java/org/dimdev/riftloader/RiftLoader.java
@@ -29,7 +29,8 @@ public class RiftLoader {
     public static final RiftLoader instance = new RiftLoader();
     private static final Logger log = LogManager.getLogger("RiftLoader");
 
-    public final File modsDir = new File(Launch.minecraftHome, "mods");
+    public File modsDir = new File(Launch.minecraftHome, "mods");
+    public final File modsVersionSpecifiedDir = new File(Launch.minecraftHome, "mods/1.13-Rift");
     public final File configDir = new File(Launch.minecraftHome, "config");
     private Side side;
     private boolean loaded;
@@ -48,6 +49,17 @@ public class RiftLoader {
         loaded = true;
 
         side = isClient ? Side.CLIENT : Side.SERVER;
+
+        // test if mods/"version"-Rift contains any .jar files
+        modsVersionSpecifiedDir.mkdir();
+        for (File tempFile : modsVersionSpecifiedDir.listFiles()) {
+            // test if dir contains any .jar files
+            if (tempFile.getName().toLowerCase().endsWith((".jar"))) {
+                // load mods from mods/"version"-Rift folder
+                modsDir = modsVersionSpecifiedDir;
+                break;
+            }
+        }
 
         findMods(modsDir);
         sortMods();

--- a/src/main/java/org/dimdev/riftloader/RiftLoader.java
+++ b/src/main/java/org/dimdev/riftloader/RiftLoader.java
@@ -30,7 +30,7 @@ public class RiftLoader {
     private static final Logger log = LogManager.getLogger("RiftLoader");
 
     public File modsDir = new File(Launch.minecraftHome, "mods");
-    public final File modsVersionSpecifiedDir = new File(Launch.minecraftHome, "mods/1.13-Rift");
+    public final File modsVersionSpecifiedDir = new File(Launch.minecraftHome, "mods/@MCVERSION@-Rift");
     public final File configDir = new File(Launch.minecraftHome, "config");
     private Side side;
     private boolean loaded;

--- a/src/main/java/org/dimdev/riftloader/RiftLoader.java
+++ b/src/main/java/org/dimdev/riftloader/RiftLoader.java
@@ -126,7 +126,7 @@ public class RiftLoader {
         log.info("Searching for mods in " + modsDir);
         if (createDir) modsDir.mkdirs();
         for (File file : modsDir.listFiles()) {
-            if (!file.getName().endsWith(".jar")) continue;
+             if (!file.getName().toLowerCase().endsWith(".jar")) continue;
 
             try (JarFile jar = new JarFile(file)) {
                 // Check if the file contains a 'riftmod.json'


### PR DESCRIPTION
Let Rift to try loading mods form the `mods/"version"-Rift` folder. If empty, fall back to "mods/" instead.
p.s. I removed the "final" flag from variable `modsDir`, not sure if there are any consequences.